### PR TITLE
build: bump Driver For Apache Cassandra to 4.9.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ spockVersion=2.0-M2-groovy-3.0
 developers=Graeme Rocher
 githubBranch=master
 githubSlug=micronaut-projects/micronaut-cassandra
-datastaxCassandraDriverVersion=4.8.0
+datastaxCassandraDriverVersion=4.9.0
 projectDesc=Provides integration between Micronaut and Cassandra
 projectUrl=https://micronaut.io
 


### PR DESCRIPTION
[Release Notes](https://github.com/datastax/java-driver/releases/tag/4.9.0)

[Datastax Java Driver for Apache Cassandra 4.9.0](https://docs.datastax.com/en/developer/java-driver/4.9/)