### PR TITLE
Add CqlSession customizers

### DIFF
--- a/cassandra/src/main/java/io/micronaut/configuration/cassandra/CassandraSessionFactory.java
+++ b/cassandra/src/main/java/io/micronaut/configuration/cassandra/CassandraSessionFactory.java
@@ -78,12 +78,17 @@ public class CassandraSessionFactory implements AutoCloseable {
      * Creates the {@link CqlSession} bean for the given configuration.
      *
      * @param builder The {@link CqlSessionBuilder}
+     * @param customizers list of {@link CqlSessionCustomizer}
      * @return A {@link CqlSession} bean
      */
     @EachBean(CqlSessionBuilder.class)
     @Bean(preDestroy = "close")
-    public CqlSession cassandraCluster(CqlSessionBuilder builder) {
-        CqlSession session = builder.build();
+    public CqlSession cassandraCluster(CqlSessionBuilder builder, List<CqlSessionCustomizer> customizers) {
+        CqlSessionBuilder sessionBuilder = builder;
+        for (CqlSessionCustomizer customizer : customizers) {
+            sessionBuilder = customizer.customize(sessionBuilder);
+        }
+        CqlSession session = sessionBuilder.build();
         this.sessions.add(session);
         return session;
     }

--- a/cassandra/src/main/java/io/micronaut/configuration/cassandra/CqlSessionCustomizer.java
+++ b/cassandra/src/main/java/io/micronaut/configuration/cassandra/CqlSessionCustomizer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.cassandra;
+
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+
+/**
+ * Allows customization of the CqlSession.
+ *
+ * @author Rafael Acevedo
+ */
+public interface CqlSessionCustomizer {
+  CqlSessionBuilder customize(CqlSessionBuilder cqlSessionBuilder);
+}

--- a/cassandra/src/test/groovy/io/micronaut/configuration/cassandra/SampleCustomizer.groovy
+++ b/cassandra/src/test/groovy/io/micronaut/configuration/cassandra/SampleCustomizer.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.configuration.cassandra
+
+
+import com.datastax.oss.driver.api.core.CqlSessionBuilder
+import io.micronaut.context.annotation.Requires
+
+import javax.inject.Singleton
+
+@Singleton
+@Requires(beans = CqlSessionBuilder.class, property = "cassandra.customizer", value = "true")
+class SampleCustomizer implements CqlSessionCustomizer {
+    public static final String LOCAL_DC = "my-different-dc"
+
+    @Override
+    CqlSessionBuilder customize(CqlSessionBuilder cqlSessionBuilder) {
+        return cqlSessionBuilder.withLocalDatacenter(LOCAL_DC)
+    }
+}


### PR DESCRIPTION
This enables users to include generic modifications to the CqlSession (like using a specific metric registry created by micronaut).

Please note that this does not include documentation changes. If it gets merged, I can include some documentation.