### PR TITLE
Require cqlsession bean on health indicator

### DIFF
--- a/cassandra/src/main/java/io/micronaut/configuration/cassandra/health/CassandraHealthIndicator.java
+++ b/cassandra/src/main/java/io/micronaut/configuration/cassandra/health/CassandraHealthIndicator.java
@@ -36,7 +36,7 @@ import java.util.*;
  * @since 2.2.0
  */
 @Requires(property = HealthEndpoint.PREFIX + ".cassandra.enabled", notEquals = "false")
-@Requires(beans = HealthEndpoint.class)
+@Requires(beans = {HealthEndpoint.class, CqlSession.class})
 @Singleton
 public class CassandraHealthIndicator extends AbstractHealthIndicator<Map<String, Object>> {
 


### PR DESCRIPTION
Currently the `CassandraHealthIndicator` fails to load when there is a `HealthEndpoint` bean but no `CqlSession` with the following error:
```
Caused by: io.micronaut.context.exceptions.DependencyInjectionException: Failed to inject value for parameter [cqlSession] of class: io.micronaut.configuration.cassandra.health.CassandraHealthIndicator
```

This fixes it by making the health indicator bean require a CqlSession bean.
