### PR TITLE
Fix resource leak issue in datastaxCassandraDriver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ micronautTestVersion=3.0.3
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0
 
-datastaxCassandraDriverVersion=4.11.1
+datastaxCassandraDriverVersion=4.14.1
 
 title=Micronaut Cassandra
 projectDesc=Provides integration between Micronaut and Cassandra


### PR DESCRIPTION
There is currently a potential resource leak when attempting todo batch insert against Cassandra db with datastax-cassandra-driver-version 4.11.1 see data stack Jira board:

- https://datastax-oss.atlassian.net/browse/JAVA-2947
- https://datastax-oss.atlassian.net/browse/JAVA-3004

This leak was reproducible using micronaut-cassandra version 4.0.0, which is pulling down dependency version 4.11.1 of datastax-cassandra-driver.

The fix for the resource leak is available for datastax-cassandra-driver from >= 4.11.2 versions onwards.

Recommended to use latest version of datastax-cassandra-driver: [4.14.1](https://github.com/datastax/java-driver/releases/tag/4.14.1)

See issues raised: 
- https://github.com/micronaut-projects/micronaut-cassandra/issues/248
- https://github.com/micronaut-projects/micronaut-cassandra/issues/250