### PR TITLE
bug: DependencyCheck is initialized at build time

### DIFF
--- a/cassandra/src/main/resources/META-INF/native-image/io.micronaut.cassandra/cassandra/native-image.properties
+++ b/cassandra/src/main/resources/META-INF/native-image/io.micronaut.cassandra/cassandra/native-image.properties
@@ -15,4 +15,4 @@
 #
 
 Args = --initialize-at-run-time=io.micronaut.cassandra.health.$CassandraHealthIndicatorDefinition \
-       --initialize-at-build-time=com.datastax.oss.driver.internal.core.util.Reflection
+       --initialize-at-build-time=com.datastax.oss.driver.internal.core.util.Reflection,com.datastax.oss.driver.internal.core.util.DependencyCheck


### PR DESCRIPTION
Fixes #256

I'm not sure what version this should be released as...

This module was moved to 5.0.0 when Micronaut 3.0 came out, but then was never released...

@sdelamo If you agree, I think this should be 5.0.0, based on Micronaut 3.5.3, and attached to the 3.6.x branch?