### PR TITLE
Remove deprecated code for Micronaut Framework 5 and document breaking changes.

### DIFF
--- a/cassandra/src/main/java/io/micronaut/cassandra/health/CassandraHealthIndicator.java
+++ b/cassandra/src/main/java/io/micronaut/cassandra/health/CassandraHealthIndicator.java
@@ -24,11 +24,9 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.health.HealthStatus;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.AbstractHealthIndicator;
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.net.InetSocketAddress;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -57,22 +55,10 @@ public class CassandraHealthIndicator extends AbstractHealthIndicator<Map<String
     private final List<CqlSession> cqlSessions;
 
     /**
-     * Default constructor.
-     *
-     * @param cqlSession The cassandra {@link CqlSession} to query for details
-     * @deprecated changed to support multiple configurations (i.e. collections of {@link CqlSession} beans)
-     */
-    @Deprecated(since = "6.1.0", forRemoval = true)
-    public CassandraHealthIndicator(final CqlSession cqlSession) {
-        this.cqlSessions = Collections.singletonList(cqlSession);
-    }
-
-    /**
      * Constructs this health indicator using all configured {@link CqlSession} beans.
      *
      * @param cqlSessions The list of cassandra {@link CqlSession} to query for details
      */
-    @Inject
     public CassandraHealthIndicator(final List<CqlSession> cqlSessions) {
         this.cqlSessions = cqlSessions;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=6.3.1-SNAPSHOT
+projectVersion=7.0.0-SNAPSHOT
 projectGroup=io.micronaut.cassandra
 
 title=Micronaut Cassandra

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,0 +1,6 @@
+This section documents breaking changes between Micronaut Cassandra versions:
+
+=== Micronaut Cassandra 7.0.0
+
+- The Singleton constructor `io.micronaut.cassandra.health.CassandraHealthIndicator(CqlSession)` deprecated previously has been removed.
+`CassandraHealthIndicator(List<CqlSession>)` is used instead.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,4 +6,5 @@ metrics: Micrometer Integration
 ssl: SSL Integration
 additional: Additional Notes
 graalvm: GraalVM support
+breaks: Breaking Changes
 repository: Repository


### PR DESCRIPTION
closes #422

Note: I created a new branch 6.3.x for Micronaut Framework 4 maintenance. Once this PR is merged master targets Micronaut Framework 5.